### PR TITLE
Fix YAML config path

### DIFF
--- a/app/utils/yaml_config.py
+++ b/app/utils/yaml_config.py
@@ -62,7 +62,7 @@ def load_yaml_file(file_path: str) -> Dict[str, Any]:
         Dictionary with config data, empty dict if file not found
     """
     try:
-        with open(file_path, 'r') as file:
+        with open(file_path, 'r', encoding='utf-8') as file:
             config_data = yaml.safe_load(file) or {}
             return config_data
     except FileNotFoundError:
@@ -110,7 +110,10 @@ def load_config(env: Optional[str] = None) -> Dict[str, Any]:
         A dictionary containing all configuration settings.
     """
     # Base config directory
-    config_dir = os.path.join(os.getcwd(), 'config', 'yaml')
+    # Use the repository root relative to this file instead of the current
+    # working directory so the loader works no matter where it is invoked from.
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    config_dir = os.path.join(base_dir, 'config', 'yaml')
     
     # 1. Determine environment
     flask_env = env or os.getenv("FLASK_ENV", "dev")

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from pathlib import Path
+import importlib.util
+from types import ModuleType
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "yaml_config",
+    PROJECT_ROOT / "app" / "utils" / "yaml_config.py",
+)
+yaml_config = importlib.util.module_from_spec(spec)
+fake_yaml = ModuleType("yaml")
+fake_yaml.safe_load = lambda f: {}
+sys.modules.setdefault("yaml", fake_yaml)
+spec.loader.exec_module(yaml_config)
+
+
+def test_load_config_from_different_cwd(tmp_path, monkeypatch):
+    """load_config should work even if current working directory is elsewhere."""
+    # Change to a temporary directory
+    cwd = os.getcwd()
+    monkeypatch.chdir(tmp_path)
+
+    def fake_loader(path):
+        if path.endswith("default.yaml"):
+            return {"app": {"name": "Crowbank Intranet"}}
+        elif path.endswith("dev.yaml"):
+            return {}
+        elif path.endswith("secret.yaml"):
+            return {}
+        return {}
+
+    monkeypatch.setattr(yaml_config, "load_yaml_file", fake_loader)
+
+    try:
+        config = yaml_config.load_config(env="dev")
+    finally:
+        os.chdir(cwd)
+
+    assert config["nested"]["app"]["name"] == "Crowbank Intranet"
+


### PR DESCRIPTION
## Summary
- ensure YAML loader resolves config directory relative to repo
- read YAML files with utf-8 encoding
- add regression test for loading config from alternate working directories

## Testing
- `pytest -q`